### PR TITLE
feat: support filter writeToDisk by compilation name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ const noop = () => {};
  * @template {IncomingMessage} [RequestInternal = IncomingMessage]
  * @template {ServerResponse} [ResponseInternal = ServerResponse]
  * @typedef {Object} Options
- * @property {boolean | ((targetPath: string) => boolean)} [writeToDisk]
+ * @property {boolean | ((targetPath: string, compilationName?: string) => boolean)} [writeToDisk]
  * @property {NonNullable<Configuration["output"]>["publicPath"]} [publicPath]
  * @property {boolean | string} [index]
  * @property {boolean} [lastModified]

--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -33,7 +33,9 @@ function setupWriteToDisk(context) {
           const { targetPath, content, compilation } = info;
           const { writeToDisk: filter } = context.options;
           const allowWrite =
-            filter && typeof filter === "function" ? filter(targetPath, compilation.name) : true;
+            filter && typeof filter === "function"
+              ? filter(targetPath, compilation.name)
+              : true;
 
           if (!allowWrite) {
             return callback();

--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -29,11 +29,11 @@ function setupWriteToDisk(context) {
 
       compiler.hooks.assetEmitted.tapAsync(
         "DevMiddleware",
-        (file, info, callback) => {
-          const { targetPath, content } = info;
+        (_file, info, callback) => {
+          const { targetPath, content, compilation } = info;
           const { writeToDisk: filter } = context.options;
           const allowWrite =
-            filter && typeof filter === "function" ? filter(targetPath) : true;
+            filter && typeof filter === "function" ? filter(targetPath, compilation.name) : true;
 
           if (!allowWrite) {
             return callback();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ export = wdm;
  * @template {IncomingMessage} [RequestInternal = IncomingMessage]
  * @template {ServerResponse} [ResponseInternal = ServerResponse]
  * @typedef {Object} Options
- * @property {boolean | ((targetPath: string) => boolean)} [writeToDisk]
+ * @property {boolean | ((targetPath: string, compilationName?: string) => boolean)} [writeToDisk]
  * @property {NonNullable<Configuration["output"]>["publicPath"]} [publicPath]
  * @property {boolean | string} [index]
  * @property {boolean} [lastModified]
@@ -256,7 +256,10 @@ type Options<
   RequestInternal extends IncomingMessage = import("http").IncomingMessage,
   ResponseInternal extends ServerResponse = ServerResponse,
 > = {
-  writeToDisk?: boolean | ((targetPath: string) => boolean) | undefined;
+  writeToDisk?:
+    | boolean
+    | ((targetPath: string, compilationName?: string) => boolean)
+    | undefined;
   publicPath?: NonNullable<Configuration["output"]>["publicPath"];
   index?: string | boolean | undefined;
   lastModified?: boolean | undefined;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->
Supports filtering `writeToDisk` by compilation name, so multi-environment builds can support configuring different writeToDisk configurations.


```js
writeToDisk: (_filePath, name) => {
  return name === 'web'
}
```
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

https://github.com/web-infra-dev/rsbuild/issues/3781
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
